### PR TITLE
Fix Kotlin Gradle plugin dependency resolution.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ buildscript {
     }
     
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${libs.versions.kotlinVersion}")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${libs.versions.kotlinVersion.get()}")
     }
 }
 


### PR DESCRIPTION
The `libs.versions.kotlinVersion` from the version catalog returns a `Provider<String>`, not a direct `String`. Using it directly in string interpolation results in `provider(?)` instead of the actual version number, causing Gradle to attempt resolving a non-existent artifact `org.jetbrains.kotlin:kotlin-gradle-plugin:provider(?)`.

This change explicitly calls `.get()` to retrieve the actual version string, ensuring the dependency is resolved correctly.